### PR TITLE
f5 non fn fix for nuphy keyboard

### DIFF
--- a/dictee-ptt.py
+++ b/dictee-ptt.py
@@ -116,6 +116,7 @@ OWN_PIDFILE = f"/tmp/dictee-ptt{_UID_SUFFIX}.pid"
 EV_KEY = 1
 EV_REL = 2   # relative axes = mouse movement (never grab a pointer device)
 EV_ABS = 3   # absolute axes = touchpad / touchscreen / tablet
+MOTION_AXES = {0, 1}  # X, Y — same codes in REL and ABS
 KEY_DOWN = 1
 KEY_UP = 0
 KEY_REPEAT = 2
@@ -184,14 +185,15 @@ def find_keyboards_evdev():
         except (PermissionError, OSError):
             continue
         caps = dev.capabilities(verbose=False)
-        # EV_KEY present with the full key set, AND no pointer axes. A real
-        # keyboard never reports EV_REL/EV_ABS. Some mice and combined
-        # keyboard+mouse HID receivers expose a node with >30 keys that ALSO
-        # carries pointer movement; EVIOCGRAB-ing such a node freezes the
-        # system mouse (forum report: dictee 1.3.4, AMD/Wayland). Excluding
-        # EV_REL/EV_ABS keeps us from ever grabbing a pointer device.
+        # EV_KEY present with the full key set, AND no X/Y motion. Some mice and
+        # combined keyboard+mouse HID receivers expose a node with >30 keys that
+        # ALSO carries pointer movement; EVIOCGRAB-ing such a node freezes the
+        # system mouse (forum report: dictee 1.3.4, AMD/Wayland). Only motion
+        # disqualifies a node: media and voice keys (KEY_VOICECOMMAND) sit on a
+        # "Consumer Control" node declaring ABS_VOLUME or REL_HWHEEL, no pointer.
+        axes = set(caps.get(EV_REL, ())) | {c for c, _ in caps.get(EV_ABS, ())}
         if (EV_KEY in caps and len(caps.get(EV_KEY, [])) > 30
-                and EV_REL not in caps and EV_ABS not in caps):
+                and not axes & MOTION_AXES):
             name = dev.name.lower()
             if name in EXCLUDE_KEYBOARDS:
                 dev.close()
@@ -217,25 +219,21 @@ def find_keyboards_raw():
 
     for block in content.split("\n\n"):
         lines = block.strip().splitlines()
-        name_line = handlers_line = ev_line = ""
+        name_line = handlers_line = ""
+        axis_masks = []
         for line in lines:
             if line.startswith("N:"):
                 name_line = line
             elif line.startswith("H:"):
                 handlers_line = line
-            elif line.startswith("B: EV="):
-                ev_line = line
-        # Reject nodes that also drive a pointer — grabbing a combined
-        # keyboard+pointer HID node freezes it. Parse the EV capability bitmask
-        # and skip the node if it exposes relative (mouse) OR absolute
-        # (touchpad/touchscreen/tablet) axes. Mirrors the EV_REL/EV_ABS
-        # exclusion in find_keyboards_evdev — the H: "mouse" handler check alone
-        # misses abs-only pointers.
-        has_pointer = False
-        m_ev = re.search(r"B: EV=([0-9a-fA-F]+)", ev_line)
-        if m_ev:
-            ev_caps = int(m_ev.group(1), 16)
-            has_pointer = bool(ev_caps & (1 << EV_REL)) or bool(ev_caps & (1 << EV_ABS))
+            elif line.startswith(("B: REL=", "B: ABS=")):
+                axis_masks.append(line)
+        # Same rule as find_keyboards_evdev: only X/Y motion disqualifies a
+        # node, so read the REL/ABS masks — "B: EV=" says only THAT the node has
+        # axes, not which ones. Each mask prints as 64-bit words, most
+        # significant first, so X (bit 0) and Y (bit 1) are in the last word.
+        has_pointer = any(int(m.rsplit("=", 1)[1].split()[-1], 16) & 0b11
+                          for m in axis_masks)
         # Require the kbd handler but reject pointer devices.
         if "kbd" in handlers_line and "mouse" not in handlers_line and not has_pointer:
             name_lower = name_line.lower()

--- a/dictee-setup.py
+++ b/dictee-setup.py
@@ -3127,6 +3127,7 @@ class ShortcutButton(QPushButton):
         super().__init__(_("Click to capture a shortcut…"), parent)
         self._capturing = False
         self._sequence = None
+        self._keycode = 0
         self._changed = False
         self.clicked.connect(self._start_capture)
 
@@ -3173,6 +3174,11 @@ class ShortcutButton(QPushButton):
         key_int = key.value if hasattr(key, "value") else int(key)
         mod_int = modifiers.value if hasattr(modifiers, "value") else int(modifiers)
         seq = QKeySequence(mod_int | key_int)
+        # X11 and Wayland both report the evdev keycode + 8 as the scan code.
+        # Media and voice keys have no Qt keysym, so key() is 0 and the
+        # QKeySequence renders empty — the scan code is the only way to read
+        # them, and it needs no per-key table.
+        self._keycode = max(event.nativeScanCode() - 8, 0)
 
         self._capturing = False
         self._sequence = seq
@@ -3191,6 +3197,10 @@ class ShortcutButton(QPushButton):
 
     def sequence(self):
         return self._sequence
+
+    def keycode(self):
+        """evdev keycode of the captured key (0 if nothing was captured)."""
+        return self._keycode
 
 
 # === Audio sources ===
@@ -16946,7 +16956,7 @@ class DicteeSetupDialog(QDialog):
     # -- Capture raccourci --
 
     def _on_ptt_key_captured(self, seq):
-        code = qt_key_to_linux_keycode(seq)
+        code = self.btn_capture.keycode() or qt_key_to_linux_keycode(seq)
         if code:
             self._ptt_key = code
             self.btn_capture.setText(_("Key: {name}").format(name=linux_keycode_name(code)))
@@ -16968,7 +16978,7 @@ class DicteeSetupDialog(QDialog):
             self.lbl_ptt_warning.setVisible(True)
 
     def _on_ptt_key_translate_captured(self, seq):
-        code = qt_key_to_linux_keycode(seq)
+        code = self.btn_capture_translate.keycode() or qt_key_to_linux_keycode(seq)
         if code:
             self._ptt_key_translate = code
             self.btn_capture_translate.setText(_("Key: {name}").format(name=linux_keycode_name(code)))


### PR DESCRIPTION
**VIBE CODED by claude opus 5**
I'm fine if you're drop this and just use as a guidance. 
Tested - works fine.

## Allow media/voice keys as the push-to-talk key

The mic key on a keyboard's media row can't be used for dictation today.
Two causes, both from identifying a key by something other than its evdev code.

**`dictee-ptt` never read the device.** `find_keyboards_evdev()` rejected any
node exposing `EV_REL`/`EV_ABS` to avoid `EVIOCGRAB` freezing the pointer on a
combined keyboard+mouse node. But media keys sit on a separate "Consumer
Control" node that declares `ABS_VOLUME`/`REL_HWHEEL` and drives no pointer, so
it was excluded too. Now only nodes reporting X/Y motion are rejected — mice,
touchpads and tablets are still excluded. `find_keyboards_raw()` had the same
flaw via `B: EV=`, which says only *that* a node has axes, not which; it now
reads the `B: REL=`/`B: ABS=` masks.

**The wizard couldn't capture it.** `ShortcutButton` mapped `QKeyEvent.key()`
through a hardcoded table. `key()` is a keysym, and media keys have none, so it
was `0`: the button rendered empty and Apply silently kept the old key.
`nativeScanCode()` is the evdev keycode + 8 on X11 and Wayland, works for any
key and needs no table. Preferred now, table kept as fallback.

No new config or dependencies.

### Testing
Fedora 44, Plasma 6.7.3 Wayland, NuPhy Air96 V2 (mic key = `KEY_VOICECOMMAND`).
Accepted nodes go from `[4,8,14,20]` to `[4,7,8,11,14,20,21]`; all newly
accepted are motion-free, no pointer node grabbed, mouse unaffected.

Still unverified: the F5 round-trip on the tightened build, and whether grabbing event7 kills your volume wheel.
